### PR TITLE
make temp blocks explicit

### DIFF
--- a/internal/qcompile/compile_expr.go
+++ b/internal/qcompile/compile_expr.go
@@ -29,14 +29,16 @@ func (cl *compiler) compileTempExpr(e ast.Expr) ir.Slot {
 }
 
 func (cl *compiler) compileRootTempExpr(e ast.Expr) ir.Slot {
+	cl.beginTempBlock()
 	slot := cl.compileTempExpr(e)
-	cl.freeTemp()
+	cl.endTempBlock()
 	return slot
 }
 
 func (cl *compiler) compileRootExpr(dst ir.Slot, e ast.Expr) {
+	cl.beginTempBlock()
 	cl.CompileExpr(dst, e)
-	cl.freeTemp()
+	cl.endTempBlock()
 }
 
 func (cl *compiler) CompileExpr(dst ir.Slot, e ast.Expr) {

--- a/internal/qcompile/compile_stmt.go
+++ b/internal/qcompile/compile_stmt.go
@@ -143,10 +143,12 @@ func (cl *compiler) compileAssignIndex(e *ast.IndexExpr, assign *ast.AssignStmt)
 	case typeIsBool(elemType), typeIsByte(elemType):
 		op = bytecode.OpSliceSetScalar8
 	}
+	cl.beginTempBlock()
 	valueslot := cl.compileTempExpr(assign.Rhs[0])
 	xslot := cl.compileTempExpr(e.X)
 	indexslot := cl.compileTempExpr(e.Index)
 	cl.emit3(op, xslot, indexslot, valueslot)
+	cl.endTempBlock()
 }
 
 func (cl *compiler) compileAssignStmt(assign *ast.AssignStmt) {


### PR DESCRIPTION
This helps to find temp allocation bugs (temp slot leaks).
This patch actually solves one such leak already in
compileAssignIndex method.