### PR TITLE
internal/qcompile: allow the compiler to re-use temp slots mid-expr

### DIFF
--- a/internal/e2e_test/testdata/bytesliceops/main.go
+++ b/internal/e2e_test/testdata/bytesliceops/main.go
@@ -176,7 +176,7 @@ func removeChar(s string, ch byte) string {
 }
 
 //test:disasm_opt
-// main.tolower code=80 frame=168 (7 slots: 1 params, 6 locals)
+// main.tolower code=80 frame=144 (6 slots: 1 params, 5 locals)
 //   Move temp2 = s
 //   Move temp3 = s
 //   LoadScalarConst arg0 = 1
@@ -190,8 +190,8 @@ func removeChar(s string, ch byte) string {
 //   LoadScalarConst temp4 = 65
 //   IntGtEq temp3 = temp2 temp4
 //   JumpZero L1 temp3
-//   LoadScalarConst temp5 = 90
-//   IntLtEq temp3 = temp2 temp5
+//   LoadScalarConst temp4 = 90
+//   IntLtEq temp3 = temp2 temp4
 // L1:
 //   JumpZero L2 temp3
 //   LoadScalarConst temp3 = 32
@@ -207,7 +207,7 @@ func removeChar(s string, ch byte) string {
 //   ReturnStr temp1
 //
 //test:disasm
-// main.tolower code=86 frame=168 (7 slots: 1 params, 6 locals)
+// main.tolower code=86 frame=144 (6 slots: 1 params, 5 locals)
 //   LoadScalarConst temp1 = 1
 //   Move temp2 = s
 //   Move temp3 = s
@@ -222,8 +222,8 @@ func removeChar(s string, ch byte) string {
 //   LoadScalarConst temp4 = 65
 //   IntGtEq temp3 = temp2 temp4
 //   JumpZero L1 temp3
-//   LoadScalarConst temp5 = 90
-//   IntLtEq temp3 = temp2 temp5
+//   LoadScalarConst temp4 = 90
+//   IntLtEq temp3 = temp2 temp4
 // L1:
 //   JumpZero L2 temp3
 //   LoadScalarConst temp3 = 32

--- a/internal/e2e_test/testdata/floatops/main.go
+++ b/internal/e2e_test/testdata/floatops/main.go
@@ -65,21 +65,21 @@ func abs(x float64) float64 {
 }
 
 //test:disasm_both
-// main.sqrt code=49 frame=168 (7 slots: 1 params, 6 locals)
+// main.sqrt code=49 frame=144 (6 slots: 1 params, 5 locals)
 //   LoadScalarConst temp0 = 4607182418800017408
 //   Jump L0
 // L1:
 //   FloatDiv64 temp2 = x temp0
 //   FloatAdd64 temp1 = temp0 temp2
-//   LoadScalarConst temp3 = 4611686018427387904
-//   FloatDiv64 temp0 = temp1 temp3
+//   LoadScalarConst temp2 = 4611686018427387904
+//   FloatDiv64 temp0 = temp1 temp2
 // L0:
 //   FloatDiv64 temp4 = x temp0
 //   FloatSub64 temp3 = temp4 temp0
 //   Move arg0 = temp3
 //   Call temp2 = main.abs()
-//   LoadScalarConst temp5 = 4532020583610935537
-//   FloatGt temp1 = temp2 temp5
+//   LoadScalarConst temp3 = 4532020583610935537
+//   FloatGt temp1 = temp2 temp3
 //   JumpNotZero L1 temp1
 //   ReturnScalar temp0
 func sqrt(x float64) float64 {

--- a/internal/e2e_test/testdata/funcs/main.go
+++ b/internal/e2e_test/testdata/funcs/main.go
@@ -121,7 +121,7 @@ func fnv1(s string) int {
 }
 
 //test:disasm_opt
-// main.isNumericString code=47 frame=168 (7 slots: 1 params, 6 locals)
+// main.isNumericString code=47 frame=120 (5 slots: 1 params, 4 locals)
 //   Zero temp0
 //   Jump L0
 // L3:
@@ -129,9 +129,9 @@ func fnv1(s string) int {
 //   LoadScalarConst temp3 = 48
 //   IntLt temp1 = temp2 temp3
 //   JumpNotZero L1 temp1
-//   StrIndex temp4 = s temp0
-//   LoadScalarConst temp5 = 57
-//   IntGt temp1 = temp4 temp5
+//   StrIndex temp2 = s temp0
+//   LoadScalarConst temp3 = 57
+//   IntGt temp1 = temp2 temp3
 // L1:
 //   JumpZero L2 temp1
 //   ReturnZero
@@ -143,7 +143,7 @@ func fnv1(s string) int {
 //   ReturnOne
 //
 //test:disasm
-// main.isNumericString code=50 frame=168 (7 slots: 1 params, 6 locals)
+// main.isNumericString code=50 frame=120 (5 slots: 1 params, 4 locals)
 //   Zero temp0
 //   Jump L0
 // L3:
@@ -151,9 +151,9 @@ func fnv1(s string) int {
 //   LoadScalarConst temp3 = 48
 //   IntLt temp1 = temp2 temp3
 //   JumpNotZero L1 temp1
-//   StrIndex temp4 = s temp0
-//   LoadScalarConst temp5 = 57
-//   IntGt temp1 = temp4 temp5
+//   StrIndex temp2 = s temp0
+//   LoadScalarConst temp3 = 57
+//   IntGt temp1 = temp2 temp3
 // L1:
 //   JumpZero L2 temp1
 //   ReturnZero
@@ -174,7 +174,7 @@ func isNumericString(s string) bool {
 }
 
 //test:disasm
-// main.atoi code=95 frame=240 (10 slots: 1 params, 9 locals)
+// main.atoi code=95 frame=216 (9 slots: 1 params, 8 locals)
 //   Move temp1 = s
 //   Zero temp2
 //   ScalarEq temp0 = temp1 temp2
@@ -186,8 +186,8 @@ func isNumericString(s string) bool {
 //   Zero temp2
 //   Zero temp5
 //   StrIndex temp4 = s temp5
-//   LoadScalarConst temp6 = 45
-//   ScalarEq temp3 = temp4 temp6
+//   LoadScalarConst temp5 = 45
+//   ScalarEq temp3 = temp4 temp5
 //   JumpZero L1 temp3
 //   LoadScalarConst temp1 = 1
 //   LoadScalarConst temp2 = 1
@@ -196,11 +196,11 @@ func isNumericString(s string) bool {
 // L3:
 //   LoadScalarConst temp4 = 10
 //   IntMul64 temp3 = temp0 temp4
-//   StrIndex temp7 = s temp2
-//   LoadScalarConst temp8 = 48
-//   IntSub8 temp6 = temp7 temp8
-//   Move temp5 = temp6
-//   IntAdd64 temp0 = temp3 temp5
+//   StrIndex temp6 = s temp2
+//   LoadScalarConst temp7 = 48
+//   IntSub8 temp5 = temp6 temp7
+//   Move temp4 = temp5
+//   IntAdd64 temp0 = temp3 temp4
 //   IntInc temp2
 // L2:
 //   Move temp4 = s
@@ -213,7 +213,7 @@ func isNumericString(s string) bool {
 //   ReturnScalar temp0
 //
 //test:disasm_opt
-// main.atoi code=80 frame=240 (10 slots: 1 params, 9 locals)
+// main.atoi code=80 frame=216 (9 slots: 1 params, 8 locals)
 //   JumpNotZero L0 s
 //   ReturnZero
 // L0:
@@ -222,8 +222,8 @@ func isNumericString(s string) bool {
 //   Zero temp2
 //   Zero temp5
 //   StrIndex temp4 = s temp5
-//   LoadScalarConst temp6 = 45
-//   ScalarEq temp3 = temp4 temp6
+//   LoadScalarConst temp5 = 45
+//   ScalarEq temp3 = temp4 temp5
 //   JumpZero L1 temp3
 //   LoadScalarConst temp1 = 1
 //   LoadScalarConst temp2 = 1
@@ -232,10 +232,10 @@ func isNumericString(s string) bool {
 // L3:
 //   LoadScalarConst temp4 = 10
 //   IntMul64 temp3 = temp0 temp4
-//   StrIndex temp7 = s temp2
-//   LoadScalarConst temp8 = 48
-//   IntSub8 temp6 = temp7 temp8
-//   IntAdd64 temp0 = temp3 temp6
+//   StrIndex temp6 = s temp2
+//   LoadScalarConst temp7 = 48
+//   IntSub8 temp5 = temp6 temp7
+//   IntAdd64 temp0 = temp3 temp5
 //   IntInc temp2
 // L2:
 //   IntLt temp3 = temp2 s
@@ -311,14 +311,11 @@ func countByte(s string, b byte) int {
 }
 
 //test:disasm_opt
-// main.hasPrefix code=27 frame=168 (7 slots: 2 params, 5 locals)
-//   Move temp1 = s
-//   Move temp2 = prefix
-//   IntGtEq temp0 = temp1 temp2
+// main.hasPrefix code=18 frame=96 (4 slots: 2 params, 2 locals)
+//   IntGtEq temp0 = s prefix
 //   JumpZero L0 temp0
-//   Move temp4 = prefix
-//   StrSliceTo temp3 = s temp4
-//   StrEq temp0 = temp3 prefix
+//   StrSliceTo temp1 = s prefix
+//   StrEq temp0 = temp1 prefix
 // L0:
 //   ReturnScalar temp0
 func hasPrefix(s, prefix string) bool {
@@ -355,15 +352,15 @@ func testFactorial() {
 }
 
 //test:disasm
-// main.charsum code=42 frame=192 (8 slots: 1 params, 7 locals)
+// main.charsum code=42 frame=168 (7 slots: 1 params, 6 locals)
 //   Zero temp0
 //   Zero temp1
 //   Jump L0
 // L1:
 //   Zero temp5
 //   StrIndex temp4 = s temp5
-//   LoadScalarConst temp6 = 48
-//   IntSub8 temp3 = temp4 temp6
+//   LoadScalarConst temp5 = 48
+//   IntSub8 temp3 = temp4 temp5
 //   Move temp2 = temp3
 //   IntAdd64 temp0 = temp0 temp2
 //   IntInc temp1
@@ -374,15 +371,15 @@ func testFactorial() {
 //   ReturnScalar temp0
 //
 //test:disasm_opt
-// main.charsum code=36 frame=192 (8 slots: 1 params, 7 locals)
+// main.charsum code=36 frame=168 (7 slots: 1 params, 6 locals)
 //   Zero temp0
 //   Zero temp1
 //   Jump L0
 // L1:
 //   Zero temp5
 //   StrIndex temp4 = s temp5
-//   LoadScalarConst temp6 = 48
-//   IntSub8 temp3 = temp4 temp6
+//   LoadScalarConst temp5 = 48
+//   IntSub8 temp3 = temp4 temp5
 //   IntAdd64 temp0 = temp0 temp3
 //   IntInc temp1
 // L0:

--- a/internal/e2e_test/testdata/inline/main.go
+++ b/internal/e2e_test/testdata/inline/main.go
@@ -53,12 +53,12 @@ func fx1() int { return fx2() }
 func fx() int { return fx1() }
 
 //test:disasm
-// main.isDigit code=20 frame=96 (4 slots: 1 params, 3 locals)
+// main.isDigit code=20 frame=72 (3 slots: 1 params, 2 locals)
 //   LoadScalarConst temp1 = 48
 //   IntGtEq temp0 = ch temp1
 //   JumpZero L0 temp0
-//   LoadScalarConst temp2 = 57
-//   IntLtEq temp0 = ch temp2
+//   LoadScalarConst temp1 = 57
+//   IntLtEq temp0 = ch temp1
 // L0:
 //   ReturnScalar temp0
 func isDigit(ch byte) bool {
@@ -66,12 +66,12 @@ func isDigit(ch byte) bool {
 }
 
 //test:disasm
-// main.isAlpha code=20 frame=96 (4 slots: 1 params, 3 locals)
+// main.isAlpha code=20 frame=72 (3 slots: 1 params, 2 locals)
 //   LoadScalarConst temp1 = 97
 //   IntGtEq temp0 = ch temp1
 //   JumpZero L0 temp0
-//   LoadScalarConst temp2 = 122
-//   IntLtEq temp0 = ch temp2
+//   LoadScalarConst temp1 = 122
+//   IntLtEq temp0 = ch temp1
 // L0:
 //   ReturnScalar temp0
 func isAlpha(ch byte) bool {
@@ -79,13 +79,13 @@ func isAlpha(ch byte) bool {
 }
 
 //test:disasm_opt
-// main.isAlphaNum code=54 frame=168 (7 slots: 1 params, 6 locals)
+// main.isAlphaNum code=54 frame=144 (6 slots: 1 params, 5 locals)
 //   Move temp1 = ch
 //   LoadScalarConst temp4 = 48
 //   IntGtEq temp3 = temp1 temp4
 //   JumpZero L0 temp3
-//   LoadScalarConst temp5 = 57
-//   IntLtEq temp3 = temp1 temp5
+//   LoadScalarConst temp4 = 57
+//   IntLtEq temp3 = temp1 temp4
 // L0:
 //   Move temp0 = temp3
 //   JumpNotZero L1 temp0
@@ -93,8 +93,8 @@ func isAlpha(ch byte) bool {
 //   LoadScalarConst temp4 = 97
 //   IntGtEq temp3 = temp1 temp4
 //   JumpZero L2 temp3
-//   LoadScalarConst temp5 = 122
-//   IntLtEq temp3 = temp1 temp5
+//   LoadScalarConst temp4 = 122
+//   IntLtEq temp3 = temp1 temp4
 // L2:
 //   Move temp0 = temp3
 // L1:

--- a/internal/e2e_test/testdata/intops/main.go
+++ b/internal/e2e_test/testdata/intops/main.go
@@ -65,8 +65,8 @@ func max(a, b int) int {
 //   Zero temp1
 //   ScalarEq temp0 = x temp1
 //   JumpNotZero L0 temp0
-//   LoadScalarConst temp2 = 1
-//   ScalarEq temp0 = x temp2
+//   LoadScalarConst temp1 = 1
+//   ScalarEq temp0 = x temp1
 // L0:
 //   JumpZero L1 temp0
 //   ReturnScalar x

--- a/internal/e2e_test/testdata/opt/opttest.go
+++ b/internal/e2e_test/testdata/opt/opttest.go
@@ -79,3 +79,15 @@ func addByteAsInt1(b byte, i int) int {
 func addByteAsInt2(b byte, i int) int {
 	return i + int(b)
 }
+
+//test:disasm_opt
+// opttest.binaryopTempReuse code=21 frame=144 (6 slots: 2 params, 4 locals)
+//   IntAdd64 temp2 = x y
+//   LoadScalarConst temp3 = 2
+//   IntAdd64 temp1 = temp2 temp3
+//   IntAdd64 temp2 = x y
+//   IntMul64 temp0 = temp1 temp2
+//   ReturnScalar temp0
+func binaryopTempReuse(x, y int) int {
+	return (x + y + 2) * (x + y)
+}

--- a/internal/e2e_test/testdata/opt/todo.go
+++ b/internal/e2e_test/testdata/opt/todo.go
@@ -59,12 +59,12 @@ func todoInc(i int) int {
 // TODO: fuse into <= 0.
 //
 //test:disasm_opt
-// opttest.todoFuseComparisons code=18 frame=96 (4 slots: 1 params, 3 locals)
+// opttest.todoFuseComparisons code=18 frame=72 (3 slots: 1 params, 2 locals)
 //   Zero temp1
 //   ScalarEq temp0 = i temp1
 //   JumpNotZero L0 temp0
-//   Zero temp2
-//   IntLt temp0 = i temp2
+//   Zero temp1
+//   IntLt temp0 = i temp1
 // L0:
 //   ReturnScalar temp0
 func todoFuseComparisons(i int) bool {


### PR DESCRIPTION
We don't need to keep temps allocated for binary expr LHS around for the entire binary expr; we only need to keep them while LHS is evaluated into its destination slot.